### PR TITLE
MAINT: master to main, and various maintenance tasks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    commit-message:
+      prefix: ⬆️
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
 
 jobs:
 
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+    - uses: pre-commit/action@v3.0.0
+
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,14 @@ jobs:
           pytest --durations=10 --cov=sphinx_proof --cov-report=xml --cov-report=term-missing
       - name: Create cov
         run: coverage xml
+      # TEMPORARY FIX: Disable codecov until we can get it working again
       - name: Upload to Codecov
-        if: matrix.python-version == 3.11
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.4
+        if: false
         with:
-          name: sphinx-proof-pytest-py3.11
+          name: sphinx-proof-pytests
           flags: pytests
-          file: ./coverage.xml
-          fail_ci_if_error: true
+          files: ./coverage.xml
 
   docs:
     name: Documentation build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,6 @@ on:
 
 jobs:
 
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.11
-    - uses: pre-commit/action@v3.0.0
-
   tests:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           pip install -e.[testing]
       - name: Run pytest
         run: |
-          pytest --duration=10 --cov=sphinx_proof --cov-report=xml --cov-report=term-missing
+          pytest --durations=10 --cov=sphinx_proof --cov-report=xml --cov-report=term-missing
       - name: Create cov
         run: coverage xml
       - name: Upload to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: continuous-integration
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,15 @@ jobs:
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - uses: pre-commit/action@v3.0.0
 
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
-        sphinx: [">=4,<5"]
+        python-version: ["3.10", "3.11"]
+        sphinx: [">=5,<6"]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,10 +40,10 @@ jobs:
       - name: Create cov
         run: coverage xml
       - name: Upload to Codecov
-        if: matrix.python-version == 3.7
+        if: matrix.python-version == 3.11
         uses: codecov/codecov-action@v1
         with:
-          name: sphinx-proof-pytest-py3.7
+          name: sphinx-proof-pytest-py3.11
           flags: pytests
           file: ./coverage.xml
           fail_ci_if_error: true
@@ -53,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -75,10 +75,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.11
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Build package
         run: |
           pip install wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 # Install pre-commit hooks via
 # pre-commit install
 
+exclude: >
+    (?x)^(
+      test_html/
+      test_latex/
+    )$
+
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,18 +4,18 @@
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.0
     hooks:
     - id: flake8
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.4.2
     hooks:
       - id: black

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **A proof extension for Sphinx**.
 
-This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
+This package contains a [Sphinx](http://www.sphinx-doc.org/) extension
 for producing proof, theorem, axiom, lemma, definition, criterion, remark, conjecture,
 corollary, algorithm, example, property, observation, proposition and assumption directives.
 
@@ -40,7 +40,7 @@ We welcome all contributions! See the [EBP Contributing Guide](https://executabl
 
 [rtd-badge]: https://readthedocs.org/projects/sphinx-proof/badge/?version=latest
 [rtd-link]: https://sphinx-proof.readthedocs.io/en/latest/?badge=latest
-[github-ci]: https://github.com/executablebooks/sphinx-proof/workflows/continuous-integration/badge.svg?branch=master
+[github-ci]: https://github.com/executablebooks/sphinx-proof/workflows/continuous-integration/badge.svg?branch=main
 [github-link]: https://github.com/executablebooks/sphinx-proof
-[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-proof/branch/master/graph/badge.svg
+[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-proof/branch/main/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/executablebooks/sphinx-proof

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Documentation Status][rtd-badge]][rtd-link]
 [![Github-CI][github-ci]][github-link]
 [![Coverage Status][codecov-badge]][codecov-link]
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/executablebooks/sphinx-proof/master.svg)](https://results.pre-commit.ci/latest/github/executablebooks/sphinx-proof/master)
+
 
 **A proof extension for Sphinx**.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -15,7 +15,7 @@ zreferences
 
 **A proof extension for Sphinx**.
 
-This package contains a [Sphinx](http://www.sphinx-doc.org/en/master/) extension
+This package contains a [Sphinx](http://www.sphinx-doc.org/) extension
 for producing proof, theorem, axiom, lemma, definition, criterion, remark, conjecture,
 corollary, algorithm, example, property, observation, proposition and assumption directives.
 
@@ -61,7 +61,7 @@ you may then build using `make html` and the extension will be used by your `Sph
 
 [rtd-badge]: https://readthedocs.org/projects/sphinx-proof/badge/?version=latest
 [rtd-link]: https://sphinx-proof.readthedocs.io/en/latest/?badge=latest
-[github-ci]: https://github.com/executablebooks/sphinx-proof/workflows/continuous-integration/badge.svg?branch=master
+[github-ci]: https://github.com/executablebooks/sphinx-proof/workflows/continuous-integration/badge.svg?branch=main
 [github-link]: https://github.com/executablebooks/sphinx-proof
-[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-proof/branch/master/graph/badge.svg
+[codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-proof/branch/main/graph/badge.svg
 [codecov-link]: https://codecov.io/gh/executablebooks/sphinx-proof

--- a/docs/source/install.md
+++ b/docs/source/install.md
@@ -26,6 +26,6 @@ To install `sphinx-proof` for package development:
 ```bash
 git clone https://github.com/executablebooks/sphinx-proof
 cd sphinx-proof
-git checkout master
+git checkout main
 pip install -e .[all]
 ```

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ URL = f"{BASE_URL}/archive/{VERSION}.tar.gz"
 
 # Define all extras
 extras = {
-    "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],
+    "code_style": ["flake8", "black", "pre-commit"],
     "testing": [
         "coverage",
-        "pytest>=3.6,<4",
+        "pytest~=7.1",
         "pytest-cov",
         "pytest-regressions",
         "beautifulsoup4",
@@ -32,7 +32,7 @@ extras = {
         "defusedxml",
     ],
     "rtd": [
-        "sphinx>=3.0",
+        "sphinx>=5.0",
         "sphinx-book-theme",
         "sphinxcontrib-bibtex",
         "myst-parser",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ extras = {
         "beautifulsoup4",
         "myst-parser",
         "texsoup",
+        "defusedxml",
     ],
     "rtd": [
         "sphinx>=3.0",

--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -7,6 +7,7 @@ A custom Sphinx Directive
 :copyright: Copyright 2020 by the QuantEcon team, see AUTHORS
 :licences: see LICENSE for details
 """
+
 from typing import List
 from docutils import nodes
 from docutils.nodes import Node

--- a/sphinx_proof/domain.py
+++ b/sphinx_proof/domain.py
@@ -7,7 +7,8 @@ A Proof Sphinx Domain
 :copyright: Copyright 2020 by the QuantEcon team, see AUTHORS
 :licences: see LICENSE for details
 """
-from typing import Any, Dict, Tuple, List, Callable
+
+from typing import Any, Dict, Tuple, List
 from docutils.nodes import Element, Node, document, system_message
 from sphinx.environment import BuildEnvironment
 from sphinx.addnodes import pending_xref

--- a/sphinx_proof/nodes.py
+++ b/sphinx_proof/nodes.py
@@ -7,6 +7,7 @@ Enumerable and unenumerable nodes
 :copyright: Copyright 2020 by the QuantEcon team, see AUTHORS
 :licences: see LICENSE for details
 """
+
 from docutils import nodes
 from docutils.nodes import Node
 from sphinx.writers.latex import LaTeXTranslator

--- a/tests/test_html/proof/_proof_with_labeled_math.html
+++ b/tests/test_html/proof/_proof_with_labeled_math.html
@@ -1,5 +1,5 @@
 <div class="proof admonition" id="proof">
 <p>Proof. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut</p>
 <div class="math notranslate nohighlight" id="equation-label1">
-<span class="eqno">(1)<a class="headerlink" href="#equation-label1" title="Permalink to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
+<span class="eqno">(1)<a class="headerlink" href="#equation-label1" title="Link to this equation">¶</a></span>\[P_t(x, y) = \mathbb 1\{x = y\} + t Q(x, y) + o(t)\]</div>
 </div>

--- a/tests/test_latex/test_latex_build.tex
+++ b/tests/test_latex/test_latex_build.tex
@@ -1,5 +1,10 @@
 \begin{document}
 
+\ifdefined\shorthandoff
+  \ifnum\catcode`\=\string=\active\shorthandoff{=}\fi
+  \ifnum\catcode`\"=\active\shorthandoff{"}\fi
+\fi
+
 \pagestyle{empty}
 \sphinxmaketitle
 \pagestyle{plain}

--- a/tox.ini
+++ b/tox.ini
@@ -8,17 +8,18 @@
 # `tox -r`
 
 [tox]
-envlist = py{36,37,38}
+envlist = py311-sphinx5
 skip_missing_interpreters = true
 
 [testenv]
 recreate = false
 
-[testenv:py{36,37,38}]
+[testenv:py{39,310,311,312}-sphinx{5,6,7}]
 extras = testing
 deps =
-	sphinx2: sphinx>=2,<3
-	sphinx3: sphinx>=3,<4
+	sphinx5: sphinx>=5,<6
+	sphinx6: sphinx>=6,<7
+	sphinx7: sphinx>=7,<8
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]


### PR DESCRIPTION
This PR updates `master` to `main`

- [x] updates base python to `python=3.11` for all tests and tests `3.10` and `3.11`
- [x] removes netlify powered previews (as not required)
- [x] adds `github actions` dependabot
- [x] upgrades version pinnings for `tests` to run in more recent python context
- [x] updates text fixtures
- [x] update default branch name on github