### PR TITLE
ENH: reconfigure css style

### DIFF
--- a/sphinx_proof/_static/minimal/proof.css
+++ b/sphinx_proof/_static/minimal/proof.css
@@ -113,10 +113,9 @@ div.definition p.admonition-title {
 div.remark {
 	border-color: var(--remark-border-color);
 	background-color: none;
-}
-
-div.remark p.admonition-title {
-	background-color: transparent;
+	p.admonition-title {
+		background-color: transparent;
+	}
 }
 
 /*********************************************


### PR DESCRIPTION
@DrDrij I have reconfigured the `css` based on our discussion in https://github.com/QuantEcon/lecture-python-intro/pull/493. Is that what you recommend re: priorities to get the title style to override in the context of other themes?

- [x] reconfigure css hierarchy for `remark`
- [ ] reconfigure css hierarchy for other admonitions