### PR TITLE
translate "Proof" title

### DIFF
--- a/sphinx_proof/directive.py
+++ b/sphinx_proof/directive.py
@@ -14,8 +14,12 @@ from docutils.nodes import Node
 from sphinx.util import logging
 from docutils.parsers.rst import directives
 from sphinx.util.docutils import SphinxDirective
+from sphinx.locale import get_translation
 from .nodes import unenumerable_node, NODE_TYPES
 from .nodes import proof_node
+
+MESSAGE_CATALOG_NAME = "proof"
+_ = get_translation(MESSAGE_CATALOG_NAME)
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +128,7 @@ class ProofDirective(SphinxDirective):
 
         section = nodes.admonition(classes=classes, ids=[typ])
 
-        self.content[0] = "{}. ".format(typ.title()) + self.content[0]
+        self.content[0] = "{}. ".format(_(typ.title())) + self.content[0]
         self.state.nested_parse(self.content, 0, section)
 
         node = proof_node()


### PR DESCRIPTION
Currently, internationalisation works for titles like "Theorem", but not yet for "Proof". Here is a small modification to support translating the latter.